### PR TITLE
Fix: Remove orphaned import of styles.css

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,14 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import "./styles.css";
-import Count from "./Count";
-import Carrousel  from "./Carrousel";
+import ReactDOM from "react-dom/client"; // Updated import for React 18
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+// Removed: import "./styles.css"; (file deleted)
+// Removed: import Count from "./Count"; (Count is rendered within App)
+// Removed: import Carrousel  from "./Carrousel"; (file deleted)
 
-// function App() {
-//   return (
-//     <div className="App">
-//       <h1>Countdown Timer</h1>
-//       <Carrousel />
-//       <Count />
-//     </div>
-//   );
-// }
-
-// ReactDOM.render(<App />, document.getElementById("root"));
+// The main App component now handles all primary rendering.
+// Older commented-out code referencing a local App function,
+// Carrousel, and Count directly here has been removed for clarity.
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
I removed the import for './styles.css' from 'src/index.js'. This file was deleted in a previous refactoring step as it was associated with the unused Carousel component, but the import statement was inadvertently left, causing the GitHub Actions build to fail.

Additionally, I removed other unused imports (Carrousel, Count) and commented-out legacy code from 'src/index.js' for better clarity and updated the ReactDOM import to 'react-dom/client' to match the usage of 'createRoot'.