### PR TITLE
Fix: Correct image import path in MainImage.js

### DIFF
--- a/src/MainImage.js
+++ b/src/MainImage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import image5 from '../image5.jpg';
+import image5 from './image5.jpg'; // Corrected path
 import './MainImage.css'; // Optional: if specific styles are needed
 
 function MainImage() {


### PR DESCRIPTION
Corrected the import path for `image5.jpg` within `src/MainImage.js` from `../image5.jpg` to `./image5.jpg`.

The image was already located in the `src/` directory, but the relative path in the import statement was incorrect, causing a "Module not found" error during the build process because it attempted to reference an image outside the `src/` directory.

This change ensures that `MainImage.js` correctly resolves `image5.jpg` from within the `src/` directory.