### PR TITLE
Fix: Correct GitHub Pages URL in package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Projeto de Homenagem com Animação Interativa
 
-[![Deploy to GitHub Pages](https://github.com/YourGitHubUsername/YourProjectRepositoryName/actions/workflows/deploy.yml/badge.svg)](https://github.com/YourGitHubUsername/YourProjectRepositoryName/actions/workflows/deploy.yml)
+[![Deploy to GitHub Pages](https://github.com/devcomputaria/HellenDELTREECounter/actions/workflows/deploy.yml/badge.svg)](https://github.com/devcomputaria/HellenDELTREECounter/actions/workflows/deploy.yml)
 
-**[View Live Application](https://YourGitHubUsername.github.io/YourProjectRepositoryName/)**
+**[View Live Application](https://devcomputaria.github.io/HellenDELTREECounter/)**
 
 ## Em Memória de Hellen DELTREE (EscravOps)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hellen-deltree-counter",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://YourGitHubUsername.github.io/YourProjectRepositoryName/",
+  "homepage": "https://devcomputaria.github.io/HellenDELTREECounter/",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
Updated the `homepage` field in `package.json` to the correct URL: `https://devcomputaria.github.io/HellenDELTREECounter/`.

Also updated the placeholder URLs in `README.md` for the deployment status badge and the live application link to use the correct repository path: `devcomputaria/HellenDELTREECounter`.

These changes ensure that the React application builds with the correct asset paths for GitHub Pages and that the links in the README point to the correct locations. This should resolve previous 404 errors on the deployed site.