### PR TITLE
Fix: Set page background to black for better contrast

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #000000; /* Added black background */
+  color: white; /* Added default white text color */
 }
 
 code {


### PR DESCRIPTION
Updated `src/index.css` to apply `background-color: #000000;` (black) and a default `color: white;` to the `body` element.

This change implements a dark theme foundation for the application, providing better contrast for the blue and white particles in the animated background and ensuring that light-colored text elements remain clearly legible.